### PR TITLE
Add crates.io publishing and migrate to dedicated homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,27 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
+  publish-crates-io:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-24.04"
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set version from tag
+        run: |
+          VERSION="${{ needs.plan.outputs.tag }}"
+          VERSION="${VERSION#v}"
+          sed -i 's/^version = .*/version = "'"$VERSION"'"/' Cargo.toml
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+      - name: Publish to crates.io
+        run: cargo publish --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   publish-homebrew-formula:
     needs:
       - plan
@@ -323,7 +344,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: true
-          repository: "kylechamberlin/homebrew-tap"
+          repository: "kylechamberlin/homebrew-funky"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae
@@ -395,10 +416,11 @@ jobs:
       - host
       - publish-homebrew-formula
       - sign-artifacts
+      - publish-crates-io
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.sign-artifacts.result == 'skipped' || needs.sign-artifacts.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.sign-artifacts.result == 'skipped' || needs.sign-artifacts.result == 'success') && (needs.publish-crates-io.result == 'skipped' || needs.publish-crates-io.result == 'success') }}
     runs-on: "ubuntu-24.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,6 +45,14 @@ jobs:
           if [ ! -s deny-results.sarif ] || ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" deny-results.sarif 2>/dev/null; then
             echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"cargo-deny","informationUri":"https://github.com/EmbarkStudios/cargo-deny"}},"results":[]}]}' > deny-results.sarif
           fi
+      - name: Fix SARIF schema
+        if: always()
+        run: |
+          jq 'walk(if type == "object" and has("region") and (.region | type) == "object" then
+            .region |= (
+              (if has("snippet") and (.snippet | type) == "string" then .snippet = {text: .snippet} else . end) |
+              (if has("message") and (.message | type) == "string" then .message = {text: .message} else . end)
+            ) else . end)' deny-results.sarif > deny-results-fixed.sarif && mv deny-results-fixed.sarif deny-results.sarif
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
-0.1.0
-=====
+# Changelog
 
-- [ ] Zsh init
-- [x] shell functions with no arguments
-- [ ] function source Vargs
-- [ ] function source History
+All releases follow [CalVer](https://calver.org/): **`vYYYY.MM.MICRO`**
+
+## Unreleased
+
+### Added
+
+- `funky new` — create shell functions from arguments, history, stdin, or clipboard
+- `funky init` — configure zsh to autoload Funky-managed functions
+- `funky list` — enumerate stored functions
+- `funky edit` — open functions in your editor
+- Interactive wizard with history browsing and argument parameterization
+- Extended zsh history format parsing
+- Duplicate detection with `--overwrite` flag
+- crates.io publishing in release pipeline

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ targets = [
   "i686-unknown-linux-gnu",
   "i686-pc-windows-gnu",
 ]
-tap = "kylechamberlin/homebrew-tap"
+tap = "kylechamberlin/homebrew-funky"
 publish-jobs = ["homebrew"]
 github-attestations = true
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -3,7 +3,7 @@
 ## Homebrew <Badge type="tip" text="recommended" />
 
 ```sh
-brew install kylechamberlin/tap/funky
+brew install kylechamberlin/funky/funky
 ```
 
 ## Shell Installer

--- a/docs/workflows/implementation-plan.md
+++ b/docs/workflows/implementation-plan.md
@@ -95,7 +95,7 @@ Implement in this order to allow incremental validation:
 | 3.3 | Set `Cargo.toml` version to placeholder | `version = "0.0.0-dev"` — real version comes from tag |
 | 3.4 | Run `dist generate` | Generates `.github/workflows/release.yml` |
 | 3.5 | Add "Set version from tag" steps | Inject `sed` step after each checkout in plan, build-local, build-global, host jobs |
-| 3.6 | Create `kylechamberlin/homebrew-tap` repo | Empty repo on GitHub — cargo-dist pushes the formula automatically |
+| 3.6 | Create `kylechamberlin/homebrew-funky` repo | Empty repo on GitHub — cargo-dist pushes the formula automatically |
 | 3.7 | Delete `.github/workflows/create_release.yml` | Old workflow removed |
 | 3.8 | Test with a release tag | Push `v2026.4.0` to validate |
 

--- a/docs/workflows/release.md
+++ b/docs/workflows/release.md
@@ -95,7 +95,7 @@ targets = [
   "i686-unknown-linux-gnu",
   "i686-pc-windows-gnu",
 ]
-tap = "kylechamberlin/homebrew-tap"
+tap = "kylechamberlin/homebrew-funky"
 publish-jobs = ["homebrew"]
 github-attestations = true
 
@@ -113,7 +113,8 @@ inherits = "release"
 cargo-dist generates a multi-job workflow following this pipeline:
 
 ```
-plan → build-local-artifacts → host (create GH release) → publish-homebrew-formula → announce
+plan → build-local-artifacts → host (create GH release) → publish-homebrew-formula ─┐
+                                                         → publish-crates-io ────────┤→ announce
 ```
 
 | Job | Purpose |
@@ -121,7 +122,8 @@ plan → build-local-artifacts → host (create GH release) → publish-homebrew
 | `plan` | Compute build matrix, determine which artifacts to produce |
 | `build-local-artifacts` | Matrix build across all targets, produce archives + checksums |
 | `host` | Create GitHub Release, upload all artifacts, generate attestations |
-| `publish-homebrew-formula` | Push updated formula to `kylechamberlin/homebrew-tap` |
+| `publish-homebrew-formula` | Push updated formula to `kylechamberlin/homebrew-funky` |
+| `publish-crates-io` | Publish crate to crates.io (enables `cargo install` and `cargo binstall`) |
 | `announce` | Post-release notifications (if configured) |
 
 ### Installers generated
@@ -130,8 +132,19 @@ plan → build-local-artifacts → host (create GH release) → publish-homebrew
 |-----------|---------------------|
 | **Shell** (`install.sh`) | `curl --proto '=https' --tlsv1.2 -LsSf https://github.com/kylechamberlin/funky/releases/latest/download/funky-installer.sh \| sh` |
 | **PowerShell** (`install.ps1`) | `powershell -ExecutionPolicy ByPass -c "irm https://github.com/kylechamberlin/funky/releases/latest/download/funky-installer.ps1 \| iex"` |
-| **Homebrew** | `brew install kylechamberlin/tap/funky` |
-| **cargo-binstall** | `cargo binstall funky` (metadata auto-generated) |
+| **Homebrew** | `brew install kylechamberlin/funky/funky` |
+| **cargo-binstall** | `cargo binstall funky` (discovers pre-built binaries via crates.io metadata) |
+| **cargo install** | `cargo install funky` (builds from crates.io source) |
+
+### crates.io Publishing
+
+A manual `publish-crates-io` job runs alongside `publish-homebrew-formula` after the GitHub Release is created. It patches `Cargo.toml` with the CalVer version from the tag and runs `cargo publish --no-verify` (verification is skipped because CI already built and tested the release).
+
+This enables two install paths:
+- `cargo install funky` — builds from source published on crates.io
+- `cargo binstall funky` — discovers pre-built release binaries via the `repository` URL in the crate metadata
+
+The job requires a `CARGO_REGISTRY_TOKEN` repository secret (a crates.io API token with publish scope).
 
 ### Build attestations
 
@@ -169,7 +182,9 @@ None — this workflow produces binaries and attestations, not scan results.
 |------|--------|
 | `Cargo.toml` | Add `[workspace.metadata.dist]` + `[profile.dist]` sections (via `cargo dist init`) |
 | `Cargo.toml` | Keep `version = "0.0.0-dev"` — real version injected from tag at CI time |
-| Homebrew tap repo | **Create** `kylechamberlin/homebrew-tap` on GitHub (empty repo, cargo-dist pushes formula) |
+| Homebrew tap repo | **Create** `kylechamberlin/homebrew-funky` on GitHub (empty repo, cargo-dist pushes formula) |
+| `HOMEBREW_TAP_TOKEN` secret | GitHub token with write access to the tap repo |
+| `CARGO_REGISTRY_TOKEN` secret | crates.io API token with publish scope (for `publish-crates-io` job) |
 | `.github/workflows/create_release.yml` | **Delete** — replaced by cargo-dist generated workflow |
 
 ## Differences from Current `create_release.yml`
@@ -188,6 +203,7 @@ None — this workflow produces binaries and attestations, not scan results.
 | Release notes | Empty body | Auto-generated from commits |
 | Version scheme | Unspecified | CalVer `vYYYY.MM.MICRO`, resolved from tag at CI time |
 | Versioning source | Hardcoded in Cargo.toml | Git tag (Cargo.toml patched dynamically) |
+| crates.io | Not published | Published on every release (enables `cargo install` and `cargo binstall`) |
 | Maintenance | Hand-maintained YAML | `dist generate` + re-add version injection steps |
 
 ## Future Enhancements


### PR DESCRIPTION
## Summary

- **Add crates.io publishing** to the release pipeline so `cargo install funky` and `cargo binstall funky` work out of the box
- **Migrate Homebrew tap** from `kylechamberlin/homebrew-tap` to the dedicated `kylechamberlin/homebrew-funky` repo (`brew install kylechamberlin/funky/funky`)
- **Convert CHANGELOG to CalVer** — replace the vestigial semver `0.1.0` with an Unreleased section using the `vYYYY.MM.MICRO` scheme

## Changes

### Release workflow (`.github/workflows/release.yml`)
- New `publish-crates-io` job runs after `host`, parallel with `publish-homebrew-formula`
- Patches `Cargo.toml` version from git tag, then runs `cargo publish --no-verify`
- `announce` job now gates on both publish jobs

### Homebrew tap migration
- `Cargo.toml`: `tap = "kylechamberlin/homebrew-funky"`
- `release.yml`: repository reference updated
- All docs updated to `kylechamberlin/funky/funky` install syntax

### Documentation
- `docs/workflows/release.md`: pipeline diagram, job table, installers table, crates.io section, prerequisites
- `docs/guide/installation.md`: updated brew install command
- `docs/workflows/implementation-plan.md`: updated tap repo reference

## Prerequisites (already done)
- [x] `KyleChamberlin/homebrew-funky` repo created
- [x] `CARGO_REGISTRY_TOKEN` secret set on `KyleChamberlin/funky`
- [x] `HOMEBREW_TAP_TOKEN` secret set on `KyleChamberlin/funky`