### PR TITLE
Fix SARIF generation failures in CI and Security workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
+          toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - uses: taiki-e/install-action@85b24a67ef0c632dfefad70b9d5ce8fddb040754 # v2
@@ -49,8 +50,15 @@ jobs:
           | tee clippy-results.sarif
           | sarif-fmt
         continue-on-error: true
+      - name: Ensure valid SARIF
+        if: always()
+        run: |
+          if [ ! -s clippy-results.sarif ] || ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" clippy-results.sarif 2>/dev/null; then
+            echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"clippy","informationUri":"https://rust-lang.github.io/rust-clippy/"}},"results":[]}]}' > clippy-results.sarif
+          fi
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        if: always()
         with:
           sarif_file: clippy-results.sarif
           category: clippy

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,7 +39,12 @@ jobs:
           tool: cargo-deny
       - name: Generate SARIF
         if: always()
-        run: cargo deny check --format sarif --all-features advisories licenses bans sources > deny-results.sarif || true
+        run: |
+          cargo deny --all-features --format sarif check advisories licenses bans sources > deny-results.sarif || true
+          # Ensure a valid SARIF file exists even when cargo-deny produces no output
+          if [ ! -s deny-results.sarif ] || ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" deny-results.sarif 2>/dev/null; then
+            echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"cargo-deny","informationUri":"https://github.com/EmbarkStudios/cargo-deny"}},"results":[]}]}' > deny-results.sarif
+          fi
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         if: always()


### PR DESCRIPTION
## Summary

- **Fix CI quality gate**: Add missing `toolchain: stable` to `dtolnay/rust-toolchain` in the clippy-sarif job — every PR was failing because the pinned action requires an explicit toolchain input
- **Fix cargo-deny SARIF**: Correct CLI flag ordering (`--all-features` and `--format` are global flags that must precede the `check` subcommand) — the previous ordering produced empty SARIF files
- **Harden SARIF uploads**: Add validation steps with minimal valid SARIF fallbacks for both clippy and cargo-deny, ensuring `upload-sarif` never receives empty or invalid JSON

## Root Cause Analysis

Investigated 20+ failed workflow runs via `gh run list --status=failure` and `gh run view --log-failed`:

| Workflow | Job | Error | Root Cause |
|----------|-----|-------|------------|
| CI | clippy-sarif | `'toolchain' is a required input` | Missing `toolchain: stable` in `dtolnay/rust-toolchain` step |
| CI | Gate | `clippy-sarif → ❌ failure` | Gate fails because clippy-sarif is a required job |
| Security | cargo-deny | `Invalid SARIF. JSON syntax error: Unexpected end of JSON input` | `--format sarif` and `--all-features` placed after `check` subcommand (they are global flags) |

Flag ordering confirmed from cargo-deny source (`Opts` struct in `main.rs`) and the `cargo-deny-action` `action.yml`.

## Changes

### `.github/workflows/ci.yml`
- Add `toolchain: stable` to rust-toolchain step
- Add "Ensure valid SARIF" step with JSON validation + fallback
- Add `if: always()` to Upload SARIF step

### `.github/workflows/security.yml`
- Fix flag ordering: `cargo deny --all-features --format sarif check ...`
- Add SARIF validation + fallback for empty/invalid output