### PR TITLE
Add Nix flake support for installation and development

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,40 @@
+name: Nix
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - flake.nix
+      - flake.lock
+      - Cargo.toml
+      - Cargo.lock
+      - "src/**"
+      - .github/workflows/nix.yml
+  pull_request:
+    paths:
+      - flake.nix
+      - flake.lock
+      - Cargo.toml
+      - Cargo.lock
+      - "src/**"
+      - .github/workflows/nix.yml
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: nix-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  nix-build:
+    name: Nix Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31
+      - run: nix build -L
+      - run: nix flake check -L

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target/
 node_modules/
 docs/.vitepress/dist/
 docs/.vitepress/cache/
+/result

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ powershell -ExecutionPolicy ByPass -c "irm https://github.com/KyleChamberlin/fun
 cargo binstall funky
 ```
 
+### Nix
+
+```sh
+nix profile install github:KyleChamberlin/funky
+```
+
+Or try it without installing:
+
+```sh
+nix run github:KyleChamberlin/funky -- --help
+```
+
 ### From source
 
 ```sh

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -14,6 +14,17 @@ mise install
 cargo build
 ```
 
+### With Nix
+
+If you use [Nix](https://nixos.org/), the flake provides a dev shell with all dependencies:
+
+```sh
+git clone https://github.com/KyleChamberlin/funky.git
+cd funky
+nix develop
+cargo build
+```
+
 ## Tests
 
 ```sh

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -31,6 +31,18 @@ powershell -ExecutionPolicy ByPass -c "irm https://github.com/KyleChamberlin/fun
 cargo binstall funky
 ```
 
+## Nix
+
+```sh
+nix profile install github:KyleChamberlin/funky
+```
+
+Or try it without installing:
+
+```sh
+nix run github:KyleChamberlin/funky -- --help
+```
+
 ## From Source
 
 Requires [Rust](https://rustup.rs/) stable:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "funky — Turn command history into reusable shell functions.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      perSystem =
+        { self', pkgs, lib, ... }:
+        let
+          cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        in
+        {
+          packages.default = pkgs.rustPlatform.buildRustPackage {
+            pname = cargoToml.package.name;
+            version = cargoToml.package.version;
+
+            src = lib.cleanSource ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+
+            nativeBuildInputs = with pkgs; [ pkg-config ];
+
+            meta = {
+              description = cargoToml.package.description;
+              homepage = cargoToml.package.homepage;
+              license = lib.licenses.gpl3Plus;
+              mainProgram = "funky";
+            };
+          };
+
+          devShells.default = pkgs.mkShell {
+            inputsFrom = [ self'.packages.default ];
+            packages = with pkgs; [
+              cargo
+              clippy
+              rustfmt
+              rust-analyzer
+            ];
+          };
+
+          checks.build = self'.packages.default;
+        };
+
+      flake = {
+        overlays.default = final: _prev: {
+          funky = inputs.self.packages.${final.system}.default;
+        };
+      };
+    };
+}

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,9 @@
       "automergeType": "pr"
     }
   ],
+  "nix": {
+    "enabled": true
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,


### PR DESCRIPTION
## Summary

- Add `flake.nix` using flake-parts with `rustPlatform.buildRustPackage` — supports `nix profile install`, `nix run`, and `nix develop` across x86_64-linux, aarch64-linux, x86_64-darwin, and aarch64-darwin
- Add CI workflow (`.github/workflows/nix.yml`) that verifies `nix build` and `nix flake check` on both ubuntu-latest and macos-latest
- Enable Renovate's nix manager to keep `flake.lock` inputs up to date
- Add Nix install instructions to README, installation guide, and contributing guide (including `nix develop` for contributors)

## What Nix users can do

```sh
# Install
nix profile install github:KyleChamberlin/funky

# Try without installing
nix run github:KyleChamberlin/funky -- --help

# Dev shell for contributors
nix develop github:KyleChamberlin/funky
```

## Verified locally

- `nix flake check --no-build` passes for all 4 systems
- `nix build` produces a working binary (`funky --version`, `funky --help`)
- All existing unit tests pass in the Nix sandbox (no display/TTY deps in tests)