### PR TITLE
Remove cargo-deny SARIF validation workaround

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,18 +46,10 @@ jobs:
           tool: cargo-deny
       - name: Generate SARIF
         if: always()
-        run: |
-          cargo deny --all-features --format sarif \
-            check advisories licenses bans sources \
-            > deny-results.sarif || true
-          if [ ! -s deny-results.sarif ] \
-            || ! python3 -c \
-            "import json,sys; json.load(open(sys.argv[1]))" \
-            deny-results.sarif 2>/dev/null; then
-            cat <<'SARIF' > deny-results.sarif
-          {"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"cargo-deny","informationUri":"https://github.com/EmbarkStudios/cargo-deny"}},"results":[]}]}
-          SARIF
-          fi
+        run: >-
+          cargo deny --all-features --format sarif
+          check advisories licenses bans sources
+          > deny-results.sarif || true
       - name: Upload SARIF
         # v4
         uses: >-


### PR DESCRIPTION
## Summary

- Remove the python3 JSON validation and fallback SARIF heredoc from the cargo-deny job in the Security workflow

The upstream SARIF generation bug in cargo-deny has been patched and released. Since `taiki-e/install-action` already installs the latest version, the workaround is no longer needed.

## What's removed

The `Generate SARIF` step previously validated the output with python3 and wrote a fallback minimal SARIF document when the file was empty or contained invalid JSON. This was necessary because cargo-deny was producing empty SARIF output due to a bug. With the fix now upstream, the step is simplified to just the `cargo deny` invocation.